### PR TITLE
fix PHPPhotoLibrary error didFinishSavingWithError will never be triggered

### DIFF
--- a/IGRPhotoTweaks/IGRPhotoTweakViewController+PHPhotoLibrary.swift
+++ b/IGRPhotoTweaks/IGRPhotoTweakViewController+PHPhotoLibrary.swift
@@ -53,7 +53,7 @@ extension IGRPhotoTweakViewController {
     }
     
     @objc func image(image: UIImage, didFinishSavingWithError error: NSError?, contextInfo:UnsafeRawPointer) {
-        if error == nil {
+        if error != nil {
             let ac = UIAlertController(title: "Save error",
                                        message: error?.localizedDescription,
                                        preferredStyle: .alert)


### PR DESCRIPTION
I had a bunch of fixes in a larger PR, but I'll bring them in one by one. 

In this case, the UIAlertController is only triggered if error == nil, so it will never fire.